### PR TITLE
feat(context): コンテキスト層を追加

### DIFF
--- a/include/omusubi/context/connectable_context.h
+++ b/include/omusubi/context/connectable_context.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+
+namespace omusubi {
+
+// 前方宣言
+class SerialContext;
+class BluetoothContext;
+class WiFiContext;
+class BLEContext;
+
+/**
+ * @brief 接続可能なデバイスのコンテキスト
+ */
+class ConnectableContext {
+public:
+    ConnectableContext() = default;
+    virtual ~ConnectableContext() = default;
+    ConnectableContext(const ConnectableContext&) = delete;
+    ConnectableContext& operator=(const ConnectableContext&) = delete;
+    ConnectableContext(ConnectableContext&&) = delete;
+    ConnectableContext& operator=(ConnectableContext&&) = delete;
+
+    /** @brief シリアルポートコンテキストを取得（実行時） */
+    [[nodiscard]] virtual SerialContext* get_serial_context(uint8_t port) const = 0;
+
+    /** @brief シリアルポートコンテキストを取得（コンパイル時） */
+    template <uint8_t Port>
+    [[nodiscard]] SerialContext* get_serial_context() const {
+        static_assert(Port <= 2, "Serial port must be 0, 1, or 2");
+        return get_serial_context(Port);
+    }
+
+    /** @brief シリアルポート数を取得 */
+    [[nodiscard]] virtual uint8_t get_serial_count() const = 0;
+
+    /** @brief Bluetoothコンテキストを取得 */
+    [[nodiscard]] virtual BluetoothContext* get_bluetooth_context() const = 0;
+
+    /** @brief WiFiコンテキストを取得 */
+    [[nodiscard]] virtual WiFiContext* get_wifi_context() const = 0;
+
+    /** @brief BLEコンテキストを取得 */
+    [[nodiscard]] virtual BLEContext* get_ble_context() const = 0;
+};
+} // namespace omusubi

--- a/include/omusubi/context/input_context.h
+++ b/include/omusubi/context/input_context.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace omusubi {
+
+// 前方宣言（将来実装予定）
+// class ButtonContext;
+// class TouchContext;
+
+/**
+ * @brief 入力デバイスのコンテキスト
+ *
+ * @note このクラスは現在プレースホルダーです。
+ *       将来のバージョンで以下の入力コンテキストが追加予定:
+ *       - ButtonContext（ボタン入力）
+ *       - TouchContext（タッチ入力）
+ *
+ * @warning 現在このクラスには機能がありません。
+ *          プラットフォーム実装で具体的な入力デバイスアクセスを提供してください。
+ */
+class InputContext {
+public:
+    InputContext() = default;
+    virtual ~InputContext() = default;
+    InputContext(const InputContext&) = delete;
+    InputContext& operator=(const InputContext&) = delete;
+    InputContext(InputContext&&) = delete;
+    InputContext& operator=(InputContext&&) = delete;
+
+    // 入力デバイスのgetterメソッド（将来実装予定）
+    // virtual ButtonContext* get_button_context(uint8_t index) = 0;
+    // virtual TouchContext* get_touch_context() = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/context/output_context.h
+++ b/include/omusubi/context/output_context.h
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace omusubi {
+
+// 前方宣言（将来実装予定）
+// class DisplayContext;
+// class LEDContext;
+// class SpeakerContext;
+
+/**
+ * @brief 出力デバイスのコンテキスト
+ *
+ * @note このクラスは現在プレースホルダーです。
+ *       将来のバージョンで以下の出力コンテキストが追加予定:
+ *       - DisplayContext（ディスプレイ出力）
+ *       - LEDContext（LED制御）
+ *       - SpeakerContext（スピーカー出力）
+ *
+ * @warning 現在このクラスには機能がありません。
+ *          プラットフォーム実装で具体的な出力デバイスアクセスを提供してください。
+ */
+class OutputContext {
+public:
+    OutputContext() = default;
+    virtual ~OutputContext() = default;
+    OutputContext(const OutputContext&) = delete;
+    OutputContext& operator=(const OutputContext&) = delete;
+    OutputContext(OutputContext&&) = delete;
+    OutputContext& operator=(OutputContext&&) = delete;
+
+    // 出力デバイスのgetterメソッド（将来実装予定）
+    // virtual DisplayContext* get_display_context() = 0;
+    // virtual LEDContext* get_led_context() = 0;
+    // virtual SpeakerContext* get_speaker_context() = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/context/power_context.h
+++ b/include/omusubi/context/power_context.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <omusubi/core/types.h>
+
+namespace omusubi {
+
+/**
+ * @brief 電源管理コンテキスト
+ */
+class PowerContext {
+public:
+    PowerContext() = default;
+    virtual ~PowerContext() = default;
+    PowerContext(const PowerContext&) = delete;
+    PowerContext& operator=(const PowerContext&) = delete;
+    PowerContext(PowerContext&&) = delete;
+    PowerContext& operator=(PowerContext&&) = delete;
+
+    /** @brief 電源状態を取得 */
+    [[nodiscard]] virtual PowerState get_power_state() const = 0;
+
+    /** @brief バッテリーレベルを取得（0-100%） */
+    [[nodiscard]] virtual uint8_t get_battery_level() const = 0;
+
+    /** @brief 充電中かどうか */
+    [[nodiscard]] virtual bool is_charging() const = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/context/scannable_context.h
+++ b/include/omusubi/context/scannable_context.h
@@ -1,0 +1,32 @@
+#pragma once
+
+namespace omusubi {
+
+// 前方宣言
+class BluetoothContext;
+class WiFiContext;
+class BLEContext;
+
+/**
+ * @brief スキャン可能なデバイスのコンテキスト
+ */
+class ScannableContext {
+public:
+    ScannableContext() = default;
+    virtual ~ScannableContext() = default;
+    ScannableContext(const ScannableContext&) = delete;
+    ScannableContext& operator=(const ScannableContext&) = delete;
+    ScannableContext(ScannableContext&&) = delete;
+    ScannableContext& operator=(ScannableContext&&) = delete;
+
+    /** @brief Bluetoothコンテキストを取得 */
+    [[nodiscard]] virtual BluetoothContext* get_bluetooth_context() const = 0;
+
+    /** @brief WiFiコンテキストを取得 */
+    [[nodiscard]] virtual WiFiContext* get_wifi_context() const = 0;
+
+    /** @brief BLEコンテキストを取得 */
+    [[nodiscard]] virtual BLEContext* get_ble_context() const = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/context/sensor_context.h
+++ b/include/omusubi/context/sensor_context.h
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace omusubi {
+
+// 前方宣言（将来実装予定）
+// class AccelerometerContext;
+// class GyroscopeContext;
+// class TemperatureContext;
+
+/**
+ * @brief センサーデバイスのコンテキスト
+ *
+ * @note このクラスは現在プレースホルダーです。
+ *       将来のバージョンで以下のセンサーコンテキストが追加予定:
+ *       - AccelerometerContext（加速度センサー）
+ *       - GyroscopeContext（ジャイロセンサー）
+ *       - TemperatureContext（温度センサー）
+ *
+ * @warning 現在このクラスには機能がありません。
+ *          プラットフォーム実装で具体的なセンサーアクセスを提供してください。
+ */
+class SensorContext {
+public:
+    SensorContext() = default;
+    virtual ~SensorContext() = default;
+    SensorContext(const SensorContext&) = delete;
+    SensorContext& operator=(const SensorContext&) = delete;
+    SensorContext(SensorContext&&) = delete;
+    SensorContext& operator=(SensorContext&&) = delete;
+
+    // センサーデバイスのgetterメソッド（将来実装予定）
+    // virtual AccelerometerContext* get_accelerometer_context() = 0;
+    // virtual GyroscopeContext* get_gyroscope_context() = 0;
+    // virtual TemperatureContext* get_temperature_context() = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/context/system_info_context.h
+++ b/include/omusubi/context/system_info_context.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace omusubi {
+
+/**
+ * @brief システム情報コンテキスト
+ *
+ * Java設計思想: java.lang.Systemに相当
+ * - 具体型（FixedString）ではなく抽象型（std::string_view）を返す
+ * - getProperty()のような設計
+ */
+class SystemInfoContext {
+public:
+    SystemInfoContext() = default;
+    virtual ~SystemInfoContext() = default;
+    SystemInfoContext(const SystemInfoContext&) = delete;
+    SystemInfoContext& operator=(const SystemInfoContext&) = delete;
+    SystemInfoContext(SystemInfoContext&&) = delete;
+    SystemInfoContext& operator=(SystemInfoContext&&) = delete;
+
+    /** @brief デバイス名を取得（Java String相当） */
+    [[nodiscard]] virtual std::string_view get_device_name() const = 0;
+
+    /** @brief ファームウェアバージョンを取得（Java String相当） */
+    [[nodiscard]] virtual std::string_view get_firmware_version() const = 0;
+
+    /** @brief チップIDを取得 */
+    [[nodiscard]] virtual uint64_t get_chip_id() const = 0;
+
+    /** @brief 稼働時間を取得（ミリ秒） */
+    [[nodiscard]] virtual uint32_t get_uptime_ms() const = 0;
+
+    /** @brief 空きメモリを取得（バイト） */
+    [[nodiscard]] virtual uint32_t get_free_memory() const = 0;
+};
+
+} // namespace omusubi


### PR DESCRIPTION
## 概要
DIコンテナとしてのContext層（7ファイル）

- `connectable_context.h`: 接続管理コンテキスト
- `input_context.h`: 入力コンテキスト
- `output_context.h`: 出力コンテキスト
- `power_context.h`: 電源管理コンテキスト
- `scannable_context.h`: スキャンコンテキスト
- `sensor_context.h`: センサーコンテキスト
- `system_info_context.h`: システム情報コンテキスト