### PR TITLE
feat(device): デバイス層を追加

### DIFF
--- a/include/omusubi/device/ble_context.h
+++ b/include/omusubi/device/ble_context.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <omusubi/interface/connectable.h>
+#include <omusubi/interface/scannable.h>
+
+namespace omusubi {
+
+/**
+ * @brief BLE (Bluetooth Low Energy) 通信デバイス
+ */
+class BLEContext : public Connectable, public Scannable {
+public:
+    BLEContext() = default;
+    ~BLEContext() override = default;
+    BLEContext(const BLEContext&) = delete;
+    BLEContext& operator=(const BLEContext&) = delete;
+    BLEContext(BLEContext&&) = delete;
+    BLEContext& operator=(BLEContext&&) = delete;
+
+    // Connectable interface
+    [[nodiscard]] bool connect() override = 0;
+    [[nodiscard]] bool disconnect() override = 0;
+    [[nodiscard]] bool is_connected() const override = 0;
+
+    // Scannable interface
+    [[nodiscard]] bool start_scan() override = 0;
+    [[nodiscard]] bool stop_scan() override = 0;
+    [[nodiscard]] uint8_t get_found_count() const override = 0;
+    [[nodiscard]] std::string_view get_found_name(uint8_t index) const override = 0;
+    [[nodiscard]] int32_t get_found_signal_strength(uint8_t index) const override = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/device/bluetooth_context.h
+++ b/include/omusubi/device/bluetooth_context.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <omusubi/interface/connectable.h>
+#include <omusubi/interface/readable.h>
+#include <omusubi/interface/scannable.h>
+#include <omusubi/interface/writable.h>
+
+namespace omusubi {
+
+/**
+ * @brief Bluetooth Classic通信デバイス
+ */
+class BluetoothContext : public ByteReadable, public TextReadable, public ByteWritable, public TextWritable, public Connectable, public Scannable {
+public:
+    BluetoothContext() = default;
+    ~BluetoothContext() override = default;
+    BluetoothContext(const BluetoothContext&) = delete;
+    BluetoothContext& operator=(const BluetoothContext&) = delete;
+    BluetoothContext(BluetoothContext&&) = delete;
+    BluetoothContext& operator=(BluetoothContext&&) = delete;
+
+    // ByteReadable interface
+    size_t read(span<uint8_t> buffer) override = 0;
+    [[nodiscard]] size_t available() const override = 0;
+
+    // TextReadable interface
+    size_t read_line(span<char> buffer) override = 0;
+
+    // ByteWritable interface
+    size_t write(span<const uint8_t> data) override = 0;
+
+    // TextWritable interface
+    size_t write_text(span<const char> text) override = 0;
+
+    // Connectable interface
+    [[nodiscard]] bool connect() override = 0;
+    [[nodiscard]] bool disconnect() override = 0;
+    [[nodiscard]] bool is_connected() const override = 0;
+
+    // Scannable interface
+    [[nodiscard]] bool start_scan() override = 0;
+    [[nodiscard]] bool stop_scan() override = 0;
+    [[nodiscard]] uint8_t get_found_count() const override = 0;
+    [[nodiscard]] std::string_view get_found_name(uint8_t index) const override = 0;
+    [[nodiscard]] int32_t get_found_signal_strength(uint8_t index) const override = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/device/serial_context.h
+++ b/include/omusubi/device/serial_context.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <omusubi/interface/connectable.h>
+#include <omusubi/interface/readable.h>
+#include <omusubi/interface/writable.h>
+
+namespace omusubi {
+
+/**
+ * @brief シリアル通信デバイス
+ */
+class SerialContext : public ByteReadable, public TextReadable, public ByteWritable, public TextWritable, public Connectable {
+public:
+    SerialContext() = default;
+    ~SerialContext() override = default;
+    SerialContext(const SerialContext&) = delete;
+    SerialContext& operator=(const SerialContext&) = delete;
+    SerialContext(SerialContext&&) = delete;
+    SerialContext& operator=(SerialContext&&) = delete;
+
+    // ByteReadable interface
+    size_t read(span<uint8_t> buffer) override = 0;
+    [[nodiscard]] size_t available() const override = 0;
+
+    // TextReadable interface
+    size_t read_line(span<char> buffer) override = 0;
+
+    // ByteWritable interface
+    size_t write(span<const uint8_t> data) override = 0;
+
+    // TextWritable interface
+    size_t write_text(span<const char> text) override = 0;
+
+    // Connectable interface
+    [[nodiscard]] bool connect() override = 0;
+    [[nodiscard]] bool disconnect() override = 0;
+    [[nodiscard]] bool is_connected() const override = 0;
+};
+
+} // namespace omusubi

--- a/include/omusubi/device/wifi_context.h
+++ b/include/omusubi/device/wifi_context.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <omusubi/interface/connectable.h>
+#include <omusubi/interface/scannable.h>
+
+namespace omusubi {
+
+/**
+ * @brief WiFi通信デバイス
+ */
+class WiFiContext : public Connectable, public Scannable {
+public:
+    WiFiContext() = default;
+    ~WiFiContext() override = default;
+    WiFiContext(const WiFiContext&) = delete;
+    WiFiContext& operator=(const WiFiContext&) = delete;
+    WiFiContext(WiFiContext&&) = delete;
+    WiFiContext& operator=(WiFiContext&&) = delete;
+
+    // Connectable interface
+    [[nodiscard]] bool connect() override = 0;
+    [[nodiscard]] bool disconnect() override = 0;
+    [[nodiscard]] bool is_connected() const override = 0;
+
+    // Scannable interface
+    [[nodiscard]] bool start_scan() override = 0;
+    [[nodiscard]] bool stop_scan() override = 0;
+    [[nodiscard]] uint8_t get_found_count() const override = 0;
+    [[nodiscard]] std::string_view get_found_name(uint8_t index) const override = 0;
+    [[nodiscard]] int32_t get_found_signal_strength(uint8_t index) const override = 0;
+};
+
+} // namespace omusubi


### PR DESCRIPTION
## 概要
デバイス固有のContext実装（4ファイル）

- `serial_context.h`: シリアル通信
- `wifi_context.h`: WiFi接続
- `bluetooth_context.h`: Bluetooth Classic
- `ble_context.h`: BLE